### PR TITLE
Make _client lazy and preload modules

### DIFF
--- a/lib/Jenkins/API.pm
+++ b/lib/Jenkins/API.pm
@@ -3,6 +3,8 @@ package Jenkins::API;
 use Moose;
 use JSON;
 use MIME::Base64;
+use URI;
+use REST::Client;
 
 =head1 NAME
 
@@ -20,17 +22,20 @@ has base_url => (is => 'ro', isa => 'Str', required => 1);
 has api_key => (is => 'ro', isa => 'Maybe[Str]', required => 0);
 has api_pass => (is => 'ro', isa => 'Maybe[Str]', required => 0);
 
-has '_client' => (is => 'ro', default => sub {
-    my $self = shift;
-    require REST::Client;
-    my $client = REST::Client->new();
-    $client->setHost($self->base_url);
-    if (defined($self->api_key) and defined($self->api_pass)) {
-        $client->addHeader("Authorization", "Basic " .
-                   encode_base64($self->api_key . ':' . $self->api_pass)); 
+has '_client' => (
+    is      => 'ro',
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        my $client = REST::Client->new();
+        $client->setHost($self->base_url);
+        if (defined($self->api_key) and defined($self->api_pass)) {
+            $client->addHeader("Authorization", "Basic " .
+                               encode_base64($self->api_key . ':' . $self->api_pass)); 
+        }
+        return $client;
     }
-    return $client;
-});
+);
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
The _client attribute depends on base_url, api_key and api_pass, but
there is no guarantee that they will be set when _client's default is
generated, leading to a useless REST::Client instance.

So, make _client lazy. Which exposes the fact that we're relying on
REST::Client to load the URI library. So we make our dependencies
explicit and move them to the top of the module.
