### PR TITLE
Fixed issue where trigger build requires a POST not a GET

### DIFF
--- a/lib/Jenkins/API.pm
+++ b/lib/Jenkins/API.pm
@@ -286,8 +286,8 @@ sub _trigger_build
     my $uri = URI->new($self->base_url);
     $uri->path_segments('job', $job, $build_url);
     $uri->query_form($extra_params) if $extra_params;
-    $self->_client->GET($uri->path_query);
-    return $self->_client->responseCode eq '302';
+    $self->_client->POST($uri->path_query);
+    return $self->_client->responseCode eq '201';
 }
 
 sub project_config


### PR DESCRIPTION
Jenkins errors due to the current code's GET call, have changed it to POST as suggested in error message.