### PR TITLE
allow base_url with extra path segments

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Jenkins-API
 
 {{ $NEXT }}
+        allow base_url with extra path segments
 
 0.18      2021-05-22 08:50:23+01:00 Europe/London
 

--- a/lib/Jenkins/API.pm
+++ b/lib/Jenkins/API.pm
@@ -448,7 +448,7 @@ sub project_config
     my $extra_params = shift;
 
     my $uri = URI->new($self->base_url);
-    $uri->path_segments('job', $job, 'config.xml');
+    $uri->path_segments($uri->path_segments, 'job', $job, 'config.xml');
     $uri->query_form($extra_params) if $extra_params;
     $self->_client->GET($uri->path_query);
     return $self->response_content;


### PR DESCRIPTION
Hello,

due to security, we started using Jenkins Folders for the jobs. In that case the base_url is including 2 more path segments. This patch allows base_url with extra path segments, no change for existing code that sets link with just hostname.

Best regards
Jozef