### PR TITLE
[doc] `API.pm`: Fix `trigger_build` link

### DIFF
--- a/lib/Jenkins/API.pm
+++ b/lib/Jenkins/API.pm
@@ -286,7 +286,7 @@ Trigger a build with parameters,
 
     $success = $jenkins->trigger_build_with_parameters('Test-Project', { Parameter => 'Value' } );
 
-The method behaves the same way as L<trigger_build>.
+The method behaves the same way as L</trigger_build>.
 
 =head2 build_queue
 


### PR DESCRIPTION
Else we go to https://metacpan.org/pod/trigger_build

See https://metacpan.org/release/NEWELLC/Jenkins-API-0.18/view/lib/Jenkins/API.pm#trigger_build_with_parameters